### PR TITLE
update migration_version helper to support rails 6

### DIFF
--- a/lib/generators/oath/migration/version.rb
+++ b/lib/generators/oath/migration/version.rb
@@ -1,9 +1,13 @@
 module Oath
   module Generators
     module Migration
+      def rails5_and_up?
+        Rails::VERSION::MAJOR >= 5
+      end
+
       def migration_version
-        if Rails.version.start_with? '5'
-          "[#{ActiveRecord::Migration.current_version}]"
+        if rails5_and_up?
+          "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
         end
       end
     end


### PR DESCRIPTION
migration_version was only checking for rails version 5:

```
  def migration_version
    if Rails.version.start_with? '5'
      "[#{ActiveRecord::Migration.current_version}]"
    end
  end
```

Rails 6 fails this test, and database migration template files were not emitted with
the rails version. These migrations cannot be applied successfully in Rails 6.

Changing the test in migration_version to detect rails 5 and up fixes this problem:

```
  def rails5_and_up?
    Rails::VERSION::MAJOR >= 5
  end

  def migration_version
    if rails5_and_up?
      "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
    end
  end
```

migration_version was also updated to include both the Rails major and minor version numbers.